### PR TITLE
Adapting the examples to Python3 and Jinja2 2.9

### DIFF
--- a/Jinja2/8-iterateDictionary.j2
+++ b/Jinja2/8-iterateDictionary.j2
@@ -10,6 +10,6 @@
 ! -- sorted usernames: passwords|sort|join(",")
 ! Sorted username: {{passwords|sort|join(",")}}
 !
-{% for username,password in passwords.iteritems() %}
+{% for username,password in passwords.items() %}
 user {{username}} password {{password}}
 {% endfor %}

--- a/Jinja2/B-ACL-seq-loopvar.j2
+++ b/Jinja2/B-ACL-seq-loopvar.j2
@@ -1,6 +1,7 @@
 {% for name,list in acls.items() %}
 ip access-list extended {{name}}
 {% for line in list %}
-  {{ line }}
+  {% set count = loop.index * 10 %}
+  {{ count }} {{ line }}
 {% endfor %}
 {% endfor %}

--- a/Jinja2/B-ACL-seq-loopvar.yml
+++ b/Jinja2/B-ACL-seq-loopvar.yml
@@ -1,0 +1,9 @@
+---
+acls:
+  noweb:
+    - deny tcp any any eq 80 log
+    - deny tcp any eq 80 any log
+    - permit ip any any
+  noudp:
+    - deny udp any any log
+    - permit tcp any any

--- a/Jinja2/B-ACL-sequenced.j2
+++ b/Jinja2/B-ACL-sequenced.j2
@@ -1,6 +1,14 @@
-{% for name,list in acls.iteritems() %}
+{#
+  This example no longer works in Jinja2 2.9 and later.
+
+  Jinja2 changed variable scoping rules within for loops - prior to
+  release 2.9 the variable set within a for loop retained their
+  value across loop iterations. Starting with release 2.9 the 
+  variables are reinitialized at everz iteration of the loop.
+#}
+{% for name,list in acls.items() %}
 ip access-list extended {{name}}
-{% set count = 0 %}
+{% set count = 10 %}
 {% for line in list %}
   {% set count = count + 10 %}
   {{ count }} {{ line }}

--- a/Jinja2/render.py
+++ b/Jinja2/render.py
@@ -19,13 +19,13 @@ ENV.filters['bracket_expansion'] = bracket_expansion
 
 filename = re.sub("\.$","",sys.argv[1])
 
-print '--- Reading YAML file '+filename+'.yml ---' 
+print ('--- Reading YAML file '+filename+'.yml ---')
 with open(filename + '.yml') as _: yamldict = yaml.load(_)
 
-print '--- YAML dictionary in '+filename+'.yml ---' 
+print ('--- YAML dictionary in '+filename+'.yml ---')
 pprint(yamldict)
 print
 
-print '--- Rendering template '+filename+'.j2 ---' 
+print ('--- Rendering template '+filename+'.j2 ---') 
 template = ENV.get_template(filename + ".j2")
 print(template.render(**yamldict))


### PR DESCRIPTION
* iteritems() no longer works in Python3. items() works for both
  Python2 and Python3
* print statement is a function in Python3 ==> needs parens
* variables used within for loops are initialized at every loop
  iteration in Jinja2 release 2.9 and later (previously the
  values were retained across loop iterations). The sample
  template B-ACL-seq-loopvar uses loop.index variable to
  number the ACL lines