### PR TITLE
Update get-keys.yml

### DIFF
--- a/tools/ssh-keys/get-keys.yml
+++ b/tools/ssh-keys/get-keys.yml
@@ -18,7 +18,16 @@
         that: host_keys.stdout
         msg:  "We did not get SSH key for {{inventory_hostname}}"
 
-    - file: path={{known_hosts}} state=touch
+    - name: Stat known_hosts file for existance
+      stat: path="{{ known_hosts }}"
+      register: fstat
+      run_once: true
+      
+    - name: Create known_hosts file if non-existing
+      # Creating same using 'touch' has the underisable effect of any non-ansible key additions (using ssh cmd) to file being appended to 
+      # ansible managed code block without a new line, rendering the ansible block non-unique between playbook runs and quite wasted.
+      copy: content="\n" dest="{{ known_hosts }}"
+      when: "not fstat.stat.exists"
       run_once: true
       changed_when: false
 


### PR DESCRIPTION
Creating "known_host" file using 'touch' as in the current version, has the undesirable effect of any non-ansible key additions (using ssh cmd) to this file being appended to ansible managed code block without a new line, rendering the ansible block non-unique between playbook runs and quite wasted. 

This is relevant only when the user has no ~/.ssh/known_hosts file when the script is run. The proposed update fixes this by creating a new file, if non-existing, with only a single newline in it.