### PR TITLE
Fixed pipe naming issue during virtual serial port creation

### DIFF
--- a/topologies/EOS-Leaf-and-Spine/Vagrantfile
+++ b/topologies/EOS-Leaf-and-Spine/Vagrantfile
@@ -52,6 +52,12 @@ Vagrant.configure(VAGRANTFILE_API_VER) do |config|
     config.vm.define host["name"] do |srv|
       srv.vm.box = host["box"]
 
+      # Next 4 lines are used to solve the issue occuring during serial port creation
+      srv.vm.provider :virtualbox do |vb|
+	pipeName = host["name"]
+        vb.customize ["modifyvm", :id, "--uartmode1", "server", "\\\\.\\pipe\\#{pipeName}"]    
+      end
+
       if host.key?("forwarded_ports")
         host["forwarded_ports"].each do |port|
           srv.vm.network :forwarded_port, guest: port["guest"], host: port["host"], id: port["name"]


### PR DESCRIPTION
As discussed in the Slack. 
modified vEOS Spine-Leaf "Vagrantfile" to fix virtual serial port creation issue.
Oezguer

Logs showing the issue:
_==> spine-2: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.
Command: ["startvm", "87f86db8-c103-424b-adc3-9f72a5c38f3b", "--type", "headless"]
Stderr: VBoxManage.exe: error: NamedPipe#0 failed to create named pipe \\.\pipe\vEOS-build-serial (VERR_PIPE_BUSY)
VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component ConsoleWrap, interface IConsole__