### PR TITLE
Ubuntu requirements.txt added vim, nano, and ping

### DIFF
--- a/Docker/Ubuntu/requirements.txt
+++ b/Docker/Ubuntu/requirements.txt
@@ -24,3 +24,6 @@ yamllint
 yq
 ntc-templates
 ttp
+vim
+nano
+iputils-ping


### PR DESCRIPTION
Added the following to the Ubuntu requirements.txt:
vim
nano
iputils-ping