### PR TITLE
tools/ssh-keys: use delegate_to, not "connection: local",

### DIFF
--- a/tools/ssh-keys/get-keys.yml
+++ b/tools/ssh-keys/get-keys.yml
@@ -5,13 +5,13 @@
 - name: Get SSH keys
   hosts: all
   gather_facts: no
-  connection: local
   vars:
     - known_hosts: "~/.ssh/known_hosts"
   tasks:
     - name: scan and register
       command: "ssh-keyscan -p {{ansible_port|default(22)}} {{ansible_host|default(inventory_hostname)}}"
       register: "host_keys"
+      delegate_to: localhost
       changed_when: false
 
     - assert:


### PR DESCRIPTION
forcing "connection: local" is broken because it keeps the remote host's host_vars, specifically `ansible_*` settings, which will likely not work.

this is for example discussed at https://www.reddit.com/r/ansible/comments/fcfvjh/running_things_on_the_controller_connectionlocal/